### PR TITLE
Set the document body color too

### DIFF
--- a/static/js/themes.js
+++ b/static/js/themes.js
@@ -86,6 +86,7 @@ var themes = {
   },
 
   setBgColor: function(color){
+    $('iframe[name="ace_outer"]').contents().find('iframe').contents().find(".innerdocbody").css("background-color",color);
     $('iframe[name="ace_outer"]').contents().find(".outerdocbody").css("background-color",color);
     $('.editorcontainer').css("background-color",color);
   },


### PR DESCRIPTION
John, 
Thanks for the excellent plugin! I noticed that the theme isn't updating the background-color of the document body in my version of Etherpad nor on the current test server of Etherpad so I figure something must've changed with the html. This simple patch should fix the issue so that the background color is changed in the document body too.

Mirrored setBgColor to the working setFontColor to set the document background color using the innerdocbody inside the 2-deep iframe.